### PR TITLE
add local rule to suppress finding 343080005 if curator link exists

### DIFF
--- a/jobs/snort/templates/rules/local.rules.erb
+++ b/jobs/snort/templates/rules/local.rules.erb
@@ -13,3 +13,4 @@
   if_link("curator") { |curator_link| curator_ip = curator_link.instances.first.address }
 %>
 <% if curator_ip %>suppress gen_id 1, sig_id 343080004, track by_src, ip <%= curator_ip %> <% end %>
+<% if curator_ip %>suppress gen_id 1, sig_id 343080005, track by_src, ip <%= curator_ip %> <% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/deploy-logsearch/pull/391

- add local rule to suppress finding 343080005 if curator link exists

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. This finding was already ignored for the curator job in another deployment: https://github.com/cloud-gov/deploy-logsearch/pull/391
